### PR TITLE
Fix errors because of mix indentation

### DIFF
--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -670,10 +670,9 @@ class CodeHierarchyNodeParser(NodeParser):
                     indent_char = " "
                 if tabs_count:
                     indent_char = "\t"
-                
+
                 if line_id == 0:
                     first_indent_char = indent_char
-
 
                 # Detect mixed indentation.
                 if spaces_count > 0 and tabs_count > 0:
@@ -712,7 +711,7 @@ class CodeHierarchyNodeParser(NodeParser):
 
         # Return the default indent level if only one indentation level was found.
         return indent_char, minimum_chain, first_indent_count // minimum_chain
-    
+
     @staticmethod
     def _get_comment_text(node: TextNode) -> str:
         """Gets just the natural language text for a skeletonize comment."""

--- a/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["ryanpeach"]
 name = "llama-index-packs-code-hierarchy"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"


### PR DESCRIPTION
# Description

I am hitting errors because of mixed indentation when trying to import repos like [langchain](https://github.com/langchain-ai/langchain). This change always used indent_char as space and if tab, assume it to be equivalent to 4 space chars.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
